### PR TITLE
Fix IFrame width and height mixed up

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -415,7 +415,7 @@ class Network(object):
             out.write(self.html)
 
         if notebook:
-            return IFrame(name, self.height, self.width)
+            return IFrame(name, width=self.width, height=self.height)
 
     def show(self, name):
         """


### PR DESCRIPTION
Setting width='500px' actually creates iframe with height='500px' and vice versa.