### PR TITLE
Feature/make link in node label clickable

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -392,6 +392,13 @@ class Network(object):
 
         """
         check_html(name)
+        # here, check if an href is present in the hover data
+        use_link_template = False
+        for n_title in list(map(lambda n: n["title"], self.nodes)):
+            if "href" in n_title:
+                # this tells the template to override default hover mechanics
+                use_link_template = True
+                break
         if not notebook:
             with open(self.path) as html:
                 content = html.read()
@@ -409,7 +416,8 @@ class Network(object):
                                     dot_lang=self.dot_lang,
                                     widget=self.widget,
                                     bgcolor=self.bgcolor,
-                                    conf=self.conf)
+                                    conf=self.conf,
+                                    tooltip_link=use_link_template)
 
         with open(name, "w+") as out:
             out.write(self.html)

--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -387,18 +387,22 @@ class Network(object):
         and options and updates the template to write the HTML holding
         the visualization.
 
-
         :type name_html: str
-
         """
         check_html(name)
         # here, check if an href is present in the hover data
         use_link_template = False
-        for n_title in list(map(lambda n: n["title"], self.nodes)):
-            if "href" in n_title:
-                # this tells the template to override default hover mechanics
-                use_link_template = True
-                break
+        for n in self.nodes:
+            title = n.get("title", None)
+            if title:
+                if "href" in title:
+                    """
+                    this tells the template to override default hover
+                    mechanic, as the tooltip would move with the mouse
+                    cursor which made interacting with hover data useless.
+                    """
+                    use_link_template = True
+                    break
         if not notebook:
             with open(self.path) as html:
                 content = html.read()

--- a/pyvis/templates/template.html
+++ b/pyvis/templates/template.html
@@ -95,6 +95,27 @@
             height: 600px;
         }
         {% endif %}
+
+        {% if tooltip_link %}
+        /* position absolute is important and the container has to be relative or absolute as well. */
+	    div.popup {
+            position:absolute;
+            top:0px;
+            left:0px;
+            display:none;
+            background-color:#f5f4ed;
+            -moz-border-radius: 3px;
+            -webkit-border-radius: 3px;
+            border-radius: 3px;
+            border: 1px solid #808074;
+            box-shadow: 3px 3px 10px rgba(0, 0, 0, 0.2);
+	    }
+
+	    /* hide the original tooltip */
+	    .vis-network-tooltip {
+	      display:none;
+	    }
+        {% endif %}
 </style>
 
 </head>
@@ -146,8 +167,8 @@
         {% else %}
 
         // parsing and collecting nodes and edges from the python
-        nodes = {{nodes|safe}};
-        edges = {{edges|safe}};
+        nodes = new vis.DataSet({{nodes|safe}});
+        edges = new vis.DataSet({{edges|safe}});
 
         // adding nodes and edges to the graph
         data = {nodes: nodes, edges: edges};
@@ -167,6 +188,72 @@
         {% endif %}
 
         network = new vis.Network(container, data, options);
+
+        {% if tooltip_link %}
+        // make a custom popup
+        var popup = document.createElement("div");
+        popup.className = 'popup';
+        popupTimeout = null;
+        popup.addEventListener('mouseover', function () {
+            console.log(popup)
+            if (popupTimeout !== null) {
+                clearTimeout(popupTimeout);
+                popupTimeout = null;
+            }
+        });
+        popup.addEventListener('mouseout', function () {
+            if (popupTimeout === null) {
+                hidePopup();
+            }
+        });
+        container.appendChild(popup);
+
+
+        // use the popup event to show
+        network.on("showPopup", function (params) {
+            showPopup(params);
+        });
+
+        // use the hide event to hide it
+        network.on("hidePopup", function (params) {
+            hidePopup();
+        });
+
+
+        // hiding the popup through css
+        function hidePopup() {
+            popupTimeout = setTimeout(function () { popup.style.display = 'none'; }, 500);
+        }
+
+        // showing the popup
+        function showPopup(nodeId) {
+            // get the data from the vis.DataSet
+            var nodeData = nodes.get([nodeId]);
+            popup.innerHTML = nodeData[0].title;
+
+            // get the position of the node
+            var posCanvas = network.getPositions([nodeId])[nodeId];
+
+            // get the bounding box of the node
+            var boundingBox = network.getBoundingBox(nodeId);
+
+            //position tooltip:
+            posCanvas.x = posCanvas.x + 0.5 * (boundingBox.right - boundingBox.left);
+
+            // convert coordinates to the DOM space
+            var posDOM = network.canvasToDOM(posCanvas);
+
+            // Give it an offset
+            posDOM.x += 10;
+            posDOM.y -= 20;
+
+            // show and place the tooltip.
+            popup.style.display = 'block';
+            popup.style.top = posDOM.y + 'px';
+            popup.style.left = posDOM.x + 'px';
+        }
+        {% endif %}
+
 
         {% if nodes|length > 100 %}
         network.on("stabilizationProgress", function(params) {

--- a/pyvis/tests/test_graph.py
+++ b/pyvis/tests/test_graph.py
@@ -281,12 +281,10 @@ class ConfigureTestCase(unittest.TestCase):
         self.g = Network()
         self.g.add_nodes([0, 1, 2, 3])
 
-    def test_toggle_buttons(self):
+    def test_show_buttons(self):
         self.assertFalse(self.g.options.configure['enabled'])
-        self.g.toggle_buttons(True)
+        self.g.show_buttons(True)
         self.assertTrue(self.g.options.configure['enabled'])
-        self.g.toggle_buttons(False)
-        self.assertFalse(self.g.options.configure['enabled'])
 
 
 class EdgeOptionsTestCase(unittest.TestCase):


### PR DESCRIPTION
closes #10 
Attaching links to node metadata is desired, but was always possible to include in the title attribute of a node using href. However, these links were not clickable since the hover tooltip moved with the cursor. I have included a fix for this, which is basically just the workaround described in the visjs issue here https://github.com/almende/vis/issues/952

Thanks to @AlexDM0 for the clever solution! :)

How it works: currently there is a check done before rendering the HTML page that checks if there is an href anywhere in the title attribute of any node. The template is then modified if this is the case.
`g.add_node("I am a node with a link", title=<a href=\'http://www.google.com\'>google</a>"`
This will not work within a jupyter notebook session by the way...