### PR TITLE
18 drawing wrong arrow directions

### DIFF
--- a/pyvis/edge.py
+++ b/pyvis/edge.py
@@ -5,4 +5,4 @@ class Edge(object):
         self.options['from'] = source
         self.options['to'] = dest
         if directed:
-            self.options["arrows"] = "from"
+            self.options["arrows"] = "to"

--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -5,6 +5,7 @@ from .utils import check_html
 from jinja2 import Template
 import webbrowser
 from IPython.display import IFrame
+from IPython.core.display import HTML
 from collections import defaultdict
 import networkx as nx
 import json


### PR DESCRIPTION
Switched up the Edge constructor to default to arrows pointing to dest node on directed graphs. This should close #18.