### PR TITLE
Hotfix/24 empty assertion error when using np.array

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -246,9 +246,15 @@ class Network(object):
                 nd[nodes[i]].update({k: v[i]})
 
         for node in nodes:
-            assert isinstance(node, int) or isinstance(node, str)
-            self.add_node(node, **nd[node])
-
+            # check if node is `number-like`
+            try:
+                node = int(node)
+                self.add_node(node, **nd[node])
+            except:
+                # or node could be string
+                assert isinstance(node, str)
+                self.add_node(node, **nd[node])
+            
     def num_nodes(self):
         """
         Return number of nodes

--- a/pyvis/tests/test_graph.py
+++ b/pyvis/tests/test_graph.py
@@ -200,7 +200,7 @@ class EdgeTestCase(unittest.TestCase):
         self.g.add_edge(0, 1)
         self.assertTrue(self.g.edges)
         for e in self.g.edges:
-            self.assertTrue(e["arrows"] == "from")
+            self.assertTrue(e["arrows"] == "to")
 
 
 class UtilsTestCase(unittest.TestCase):

--- a/pyvis/tests/test_me.py
+++ b/pyvis/tests/test_me.py
@@ -1,5 +1,5 @@
 from ..network import Network
-
+import numpy as np
 
 def test_canvas_size():
     """
@@ -68,3 +68,13 @@ def test_add_edge():
     net.add_edge(0, 9)
 
     assert(net.get_adj_list()[0] == set([2, 1, 3, 4, 5, 6, 7, 8, 9]))
+
+def test_add_numpy_nodes():
+    """
+    Test adding numpy array nodes since these
+    nodes will have specific numpy types
+    """
+    arrayNodes = np.array([1,2,3,4])
+    g = Network()
+    g.add_nodes(np.array([1,2,3,4]))
+    assert g.get_nodes() == [1,2,3,4]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Jinja2==2.8
+Jinja2==2.10
 networkx==1.11
 ipython==5.3.0


### PR DESCRIPTION
This closes #24 by adding a different check

```python
for node in nodes:
            # check if node is `number-like`
            try:
                node = int(node)
                self.add_node(node, **nd[node])
            except:
                # or node could be string
                assert isinstance(node, str)
                self.add_node(node, **nd[node])
```