### PR TITLE
consistent ipython version in requirements.txt and setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     install_requires=[
         "jinja2 >= 2.9.6",
         "networkx >= 1.11",
-        "ipython == 5.3.0"
+        "ipython >= 5.3.0"
     ]
 )


### PR DESCRIPTION
ipython version was >= 5.3.0 in requirements.txt and == 5.3.0 in setup.py, causing downgrading of ipython package.