### PR TITLE
allow periods in filepath by making isHTML? checks smarter

### DIFF
--- a/pyvis/utils.py
+++ b/pyvis/utils.py
@@ -8,6 +8,6 @@ def check_html(name):
     :param: name: the name to check
     :type name: str
     """
-    assert len(name.split(".")) == 2, "invalid file type for %s" % name
+    assert len(name.split(".")) >= 2, "invalid file type for %s" % name
     assert name.split(
-        ".")[1] == "html", "%s is not a valid html file" % name
+        ".")[-1] == "html", "%s is not a valid html file" % name


### PR DESCRIPTION
this commit will allow pyvis to be run in directories that contain periods as part of their filename.
there's no reason we shouldn't be able to accommodate this