### PR TITLE
Fix #25: Show loading bar only when physics is enabled

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -428,11 +428,22 @@ class Network(object):
             template = self.template
 
         nodes, edges, height, width, options = self.get_network_data()
+
+        # check if physics is enabled
+        if isinstance(self.options, dict):
+            if 'physics' in self.options and 'enabled' in self.options['physics']:
+                physics_enabled = self.options['physics']['enabled']
+            else:
+                physics_enabled = True
+        else:
+            physics_enabled = self.options.physics.enabled
+
         self.html = template.render(height=height,
                                     width=width,
                                     nodes=nodes,
                                     edges=edges,
                                     options=options,
+                                    physics_enabled=physics_enabled,
                                     use_DOT=self.use_DOT,
                                     dot_lang=self.dot_lang,
                                     widget=self.widget,

--- a/pyvis/templates/template.html
+++ b/pyvis/templates/template.html
@@ -17,7 +17,7 @@
             float: left;
         }
 
-        {% if nodes|length > 100 | physics_enabled %}
+        {% if nodes|length > 100 and physics_enabled %}
         #loadingBar {
             position:absolute;
             top:0px;
@@ -122,7 +122,7 @@
 
 <body>
 <div id = "mynetwork"></div>
-{% if nodes|length > 100 | physics_enabled %}
+{% if nodes|length > 100 and physics_enabled %}
 <div id="loadingBar">
     <div class="outerBorder">
         <div id="text">0%</div>
@@ -251,7 +251,7 @@
         {% endif %}
 
 
-        {% if nodes|length > 100 | physics_enabled %}
+        {% if nodes|length > 100 and physics_enabled %}
         network.on("stabilizationProgress", function(params) {
       		document.getElementById('loadingBar').removeAttribute("style");
 	        var maxWidth = 496;

--- a/pyvis/templates/template.html
+++ b/pyvis/templates/template.html
@@ -17,7 +17,7 @@
             float: left;
         }
 
-        {% if nodes|length > 100 %}
+        {% if nodes|length > 100 | physics_enabled %}
         #loadingBar {
             position:absolute;
             top:0px;
@@ -122,7 +122,7 @@
 
 <body>
 <div id = "mynetwork"></div>
-{% if nodes|length > 100 %}
+{% if nodes|length > 100 | physics_enabled %}
 <div id="loadingBar">
     <div class="outerBorder">
         <div id="text">0%</div>
@@ -251,7 +251,7 @@
         {% endif %}
 
 
-        {% if nodes|length > 100 %}
+        {% if nodes|length > 100 | physics_enabled %}
         network.on("stabilizationProgress", function(params) {
       		document.getElementById('loadingBar').removeAttribute("style");
 	        var maxWidth = 496;


### PR DESCRIPTION
This commit fixes #25. In the past a 0% progress bar was showed on top of the graph when physics was disabled (and there were more than 100 nodes).

Hope this will be useful