### PR TITLE
Adding jsonpickle to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ python setup.py install
 
 [ipython](https://ipython.org/ipython-doc/2/install/install.html)
 
+[jsonpickle](https://jsonpickle.github.io/)
+
 ## Quick Start
 The most basic use case of a pyvis instance is to create a Network object and invoke methods:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Jinja2>=2.10
 networkx>=1.11
 ipython>=5.3.0
 pandas>=0.23.4
-jsonpickle
+jsonpickle>=1.4.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=[
         "jinja2 >= 2.9.6",
         "networkx >= 1.11",
-        "ipython >= 5.3.0"
+        "ipython >= 5.3.0",
+        "jsonpickle >= 1.4.1"
     ]
 )


### PR DESCRIPTION
Since pyvis now depends on `jsonpickle`, we should add it to the dependency list in `setup.py` such that `jsonpickle` can be fetched along with the installation of pyvis. 