### PR TITLE
Fix #69: Show no heading output on graph if not specified 

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -31,7 +31,7 @@ class Network(object):
                  bgcolor="#ffffff",
                  font_color=False,
                  layout=None,
-                 heading=None):
+                 heading=""):
         """
         :param height: The height of the canvas
         :param width: The width of the canvas

--- a/pyvis/templates/template.html
+++ b/pyvis/templates/template.html
@@ -187,26 +187,7 @@
         {% endif %}
 
         network = new vis.Network(container, data, options);
-	
-	// creates a blinking effect for a node
-	function nodeFlash(node) {
-            updateNode(node, !nodes.get(node).hidden);
-            setTimeout(function() {
-                nodeFlash(node);
-            }, 1500);
-        }
-
-        function updateNode(node, hidden) {
-            try {
-                nodes.update({id : node, hidden : hidden});
-            } 
-            catch (err) {
-                alert(err);
-            }
-        }
 	 
-	nodeFlash(node)
-
         {% if tooltip_link %}
         // make a custom popup
         var popup = document.createElement("div");

--- a/pyvis/templates/template.html
+++ b/pyvis/templates/template.html
@@ -187,6 +187,25 @@
         {% endif %}
 
         network = new vis.Network(container, data, options);
+	
+	// creates a blinking effect for a node
+	function nodeFlash(node) {
+            updateNode(node, !nodes.get(node).hidden);
+            setTimeout(function() {
+                nodeFlash(node);
+            }, 1500);
+        }
+
+        function updateNode(node, hidden) {
+            try {
+                nodes.update({id : node, hidden : hidden});
+            } 
+            catch (err) {
+                alert(err);
+            }
+        }
+	 
+	nodeFlash(node)
 
         {% if tooltip_link %}
         // make a custom popup


### PR DESCRIPTION
The prior PR #67 displayed "None" as the heading on top of the graph even if no heading was specified when initializing the pyvis graph in issue #69. 

This PR fixes the issue #69 by displaying no heading output at all when a heading is not specified. 