### PR TITLE
tests: fix get_network_data assertion

### DIFF
--- a/pyvis/tests/test_graph.py
+++ b/pyvis/tests/test_graph.py
@@ -114,7 +114,7 @@ class NodeTestCase(unittest.TestCase):
         self.assertEqual(g.num_nodes(), 1)
 
     def test_get_network_data(self):
-        self.assertEqual(len(self.g.get_network_data()), 5)
+        self.assertEqual(len(self.g.get_network_data()), 6)
 
 
 class EdgeTestCase(unittest.TestCase):


### PR DESCRIPTION
For some reason I get 6 elements, not 5.

This seems to be my content of `self.g.get_network_data()`:

```py
([], [], '', '500px', '500px', '{\n    "configure": {\n        "enabled": false\n    },\n    "edges": {\n        "color": {\n            "inherit": true\n        },\n        "smooth": {\n            "enabled": false,\n            "type": "continuous"\n        }\n    },\n    "interaction": {\n        "dragNodes": true,\n        "hideEdgesOnDrag": false,\n        "hideNodesOnDrag": false\n    },\n    "physics": {\n        "enabled": true,\n        "stabilization": {\n            "enabled": true,\n            "fit": true,\n            "iterations": 1000,\n            "onlyDynamicEdges": false,\n            "updateInterval": 50\n        }\n    }\n}')
```