### PR TITLE
Allow custom 'arrows' options for directed graphs

### DIFF
--- a/pyvis/edge.py
+++ b/pyvis/edge.py
@@ -5,4 +5,5 @@ class Edge(object):
         self.options['from'] = source
         self.options['to'] = dest
         if directed:
-            self.options["arrows"] = "to"
+        	if 'arrows' not in self.options:
+        		self.options["arrows"] = "to"


### PR DESCRIPTION
Ignore `self.options["arrows"] = "to"` if a custom `arrows` option has been set for an edge. This is a possible solution to [Issue 99](https://github.com/WestHealth/pyvis/issues/99).