### PR TITLE
Fixed the node relabling issue

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -203,7 +203,16 @@ class Network(object):
         :type x: num (optional)
         :type y: num (optional)
         """
+
+        try:
+            n_id = int(n_id)
+        except ValueError:
+            try:
+                n_id = str(n_id)
+            except ValueError:
+                pass
         assert isinstance(n_id, str) or isinstance(n_id, int)
+        
         if label:
             node_label = label
         else:
@@ -332,6 +341,18 @@ class Network(object):
         :type width: num
         """
         edge_exists = False
+
+        try:
+            source = int(source)
+            to = int(to)
+        except ValueError:
+            try:
+                source = str(source)
+                to = str(to)
+            except ValueError:
+                pass
+        assert isinstance(source, str) or isinstance(source, int)
+        assert isinstance(to, str) or isinstance(to, int)
 
         # verify nodes exists
         assert source in self.get_nodes(), \


### PR DESCRIPTION
Hi,

You've really created a wonderful library. I'm using it in conjunction with Deep Graph Library (DGL) for my day-to-day operations.

The problem I'm attempting to solve is: How to visualize a graph created with DGL using PyVis? A concrete illustration of the problem with a MWE is presented [here](https://stackoverflow.com/questions/72761822/cannot-visualize-the-cora-dataset-using-pyvis/72763687#72763687).

Given that there is no support to visualize graphs directly issued from DGL (and maybe other graph neural network libraries too), one must go through NetworkX before visualizing the results. A problem occurs as PyVis only accepts `ints` and `strings` as node ids. A solution I found is to _attempt_ to convert the node ids to `ints` or `strings` when constructing the graphs for visualization in PyVis.

This solution offers a smoother transitions between the frameworks involved, and avoids iteratively re-mapping the node ids (which could be a problem for performance on large graphs).

I don't think this is an issue, rather a possible improvement to PyVis (hence the pull request). Do you find this helpful at all ? Please let me know :)

Cheers,
Des