### PR TITLE
added options to Network.add_nodes to match Network.add_node

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -239,8 +239,9 @@ class Network(object):
 
         :type nodes: list
         """
-        valid_args = ["size", "value", "title",
-            "x", "y", "label", "color", "shape"]
+        valid_args = ["label", "borderWidth", "borderWidthSelected", 
+        "brokenImage", "group", "hidden", "image", "labelHighlightBold", 
+        "level", "mass", "physics", "shape", "size", "title", "value", "x", "y"]
         for k in kwargs:
             assert k in valid_args, "invalid arg '" + k + "'"
 


### PR DESCRIPTION
First of all, thanks for writing such a useful library!

I've noticed that the `Network.add_nodes` method is missing keyword argument options that `Network.add_node` has. In order to bring the two functions in line with each other, I updated the `valid_args` list to contain the full set of options.