### PR TITLE
Fix #175 - prevent `save_graph` to open a browser

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -526,7 +526,7 @@ class Network(object):
 
             with open(f"{tempdir}/{name}", "w+") as out:
                 out.write(self.html)
-                webbrowser.open(f"{tempdir}/{name}")
+                # webbrowser.open(f"{tempdir}/{name}")
 
     def show(self, name, local=True):
         """
@@ -540,7 +540,7 @@ class Network(object):
             return self.write_html(name, local, notebook=True)
         else:
             self.write_html(name, local)
-            # webbrowser.open(name)
+            webbrowser.open(name)
 
     def prep_notebook(self,
                       custom_template=False, custom_template_path=None):

--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -526,7 +526,6 @@ class Network(object):
 
             with open(f"{tempdir}/{name}", "w+") as out:
                 out.write(self.html)
-                # webbrowser.open(f"{tempdir}/{name}")
 
     def show(self, name, local=True):
         """


### PR DESCRIPTION
This commit prevents `save_graph` function to open a generated graph in a webbrowser. To open graph in a webbrowser a separate function `show` must be used.