### PR TITLE
Add option to disable physics once visualization finishes loading

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -472,6 +472,7 @@ class Network(object):
                 physics_enabled = True
         else:
             physics_enabled = self.options.physics.enabled
+            physics_disabled_onload = self.options.physics.disabled_onload
 
         self.html = template.render(height=height,
                                     width=width,
@@ -480,6 +481,7 @@ class Network(object):
                                     heading=heading,
                                     options=options,
                                     physics_enabled=physics_enabled,
+                                    physics_disabled_onload=physics_disabled_onload,
                                     use_DOT=self.use_DOT,
                                     dot_lang=self.dot_lang,
                                     widget=self.widget,
@@ -964,6 +966,20 @@ class Network(object):
         :type status: bool
         """
         self.options.physics.enabled = status
+
+    def toggle_disable_physics_onload(self, status):
+        """
+        Disables (or enables) physics simulation after the visualization
+        finished loading.
+
+        :param status: When True, once the visualization has been loaded,
+                       nodes will no longer be part of the physics
+                       simulation. They will not move except for from
+                       manual dragging.
+                       Default is set to False.
+        :type status: bool
+        """
+        self.options.physics.disabled_onload = status
 
     def toggle_drag_nodes(self, status):
         """

--- a/pyvis/physics.py
+++ b/pyvis/physics.py
@@ -90,6 +90,7 @@ class Physics(object):
 
     def __init__(self):
         self.enabled = True
+        self.disabled_onload = False
         self.stabilization = self.Stabilization()
 
     def use_barnes_hut(self, params):

--- a/pyvis/templates/template.html
+++ b/pyvis/templates/template.html
@@ -543,6 +543,9 @@
                           document.getElementById('text').innerHTML = '100%';
                           document.getElementById('bar').style.width = '496px';
                           document.getElementById('loadingBar').style.opacity = 0;
+                          {% if physics_disabled_onload %}
+                          network.setOptions({physics : false});
+                          {% endif %}
                           // really clean the dom element
                           setTimeout(function () {document.getElementById('loadingBar').style.display = 'none';}, 500);
                       });

--- a/pyvis/tests/test_graph.py
+++ b/pyvis/tests/test_graph.py
@@ -243,6 +243,11 @@ class PhysicsTestCase(unittest.TestCase):
         self.g.toggle_physics(False)
         self.assertFalse(self.g.options.physics['enabled'])
 
+    def test_toggle_disable_physics_onload(self):
+        self.assertFalse(self.g.options.physics['disabled_onload'])
+        self.g.toggle_disable_physics_onload(True)
+        self.assertTrue(self.g.options.physics['disabled_onload'])
+
     def test_stabilization(self):
         self.g.toggle_stabilization(True)
         self.assertTrue(self.g.options.physics.stabilization['enabled'])


### PR DESCRIPTION
I'm currently working with a huge graph and physics during visualization are simply to much to be handled for the browser. If I disable physics (e.g. `net.toggle_physics(False)`) the graph is just a meaningless ring of nodes (as shown [here](https://github.com/WestHealth/pyvis/issues/88#issuecomment-1081375042)) since there's no physics to move each node to the right place during visualization loading). Then, I thought to myself, it would be nice to disable physics once the graph visualization has been loaded and each node is in the right place (according to the selected gravity model). Searched if this option was already incorporated in `pyvis` and since it is not included yet, I decided to made the changes to add it. Below I'll paste the description of the commit:

> Add option to disable physics onload
>
> The method `toggle_disable_physics_onload()` has been added to the
> `Network` class. This method allows the user to disable physics once the
> graph visualization has been loaded and each node is in the right place
> (according to the selected gravity model).

Solves: #88