### PR TITLE
Changed show() to only show, and write_html to only write.

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -535,7 +535,7 @@ class Network(object):
 
             with open(f"{tempdir}/{name}", "w+") as out:
                 out.write(self.html)
-                webbrowser.open(f"{tempdir}/{name}")
+                # webbrowser.open(f"{tempdir}/{name}")
 
     def show(self, name, local=True):
         """
@@ -548,8 +548,8 @@ class Network(object):
         if self.template is not None:
             return self.write_html(name, local, notebook=True)
         else:
-            self.write_html(name, local)
-            # webbrowser.open(name)
+            # self.write_html(name, local)
+            webbrowser.open(name)
 
     def prep_notebook(self,
                       custom_template=False, custom_template_path=None):


### PR DESCRIPTION
show() should only show.
write_html() should only write to html.

I have a webserver which often writes the network to an HTML element, and I want to avoid having to make a secondary script which closes down the browser if it is open. 

