### PR TITLE
Fix unnecessary webbrowser.open in network.save_graph

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -535,7 +535,7 @@ class Network(object):
 
             with open(f"{tempdir}/{name}", "w+") as out:
                 out.write(self.html)
-                webbrowser.open(f"{tempdir}/{name}")
+                # webbrowser.open(f"{tempdir}/{name}")
 
     def show(self, name, local=True):
         """
@@ -549,7 +549,7 @@ class Network(object):
             return self.write_html(name, local, notebook=True)
         else:
             self.write_html(name, local)
-            # webbrowser.open(name)
+            webbrowser.open(name)
 
     def prep_notebook(self,
                       custom_template=False, custom_template_path=None):


### PR DESCRIPTION
When a network is saved to file by `network.save_graph()`, the file should not show.
If `pyvis` is running in a headless environment, this creates a browser that has to be killed manually each time the HTML file is saved.
For these cases, it is important the save_graph method does not open the browser using `webbrowser.open()` and only does that when showing with `network.show()`.
The commit to fix Issue #175 does not fix this problem, and Pull request #192 is incorrect.