### PR TITLE
Restore backwards compatibility with version 0.3.1

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -534,7 +534,7 @@ class Network(object):
             webbrowser.open(getcwd_name)
 
 
-    def show(self, name, local=True,notebook=True):
+    def show(self, name, local=True, notebook=False):
         """
         Writes a static HTML file and saves it locally before opening.
 
@@ -543,7 +543,7 @@ class Network(object):
         """
         print(name)
         if notebook:
-            self.write_html(name, open_browser=False,notebook=True)
+            self.write_html(name, open_browser=False, notebook=True)
         else:
             self.write_html(name, open_browser=True)
         if notebook:


### PR DESCRIPTION
This fixes issue #216. See https://github.com/WestHealth/pyvis/issues/216#issuecomment-1485121389 for more details.