### PR TITLE
Clear highlight by clicking on canvas

### DIFF
--- a/pyvis/templates/template.html
+++ b/pyvis/templates/template.html
@@ -456,12 +456,8 @@
 
                   network = new vis.Network(container, data, options);
 
-                  {% if neighborhood_highlight %}
+                  {% if neighborhood_highlight or select_menu %}
                     network.on("click", neighbourhoodHighlight);
-                  {% endif %}
-
-                  {% if select_menu %}
-                    network.on("selectNode", neighbourhoodHighlight);
                   {% endif %}
 
                   {% if tooltip_link %}

--- a/pyvis/templates/template.html
+++ b/pyvis/templates/template.html
@@ -265,6 +265,7 @@
               var network;
               var container;
               var options, data;
+              var highlightActive = false;
               var filter = {
                   item : '',
                   property : '',


### PR DESCRIPTION
Currently when Network is called with `neighborhood_highlight=False, select_menu=True`, the user is able to highlight neighboring nodes by clicking on a node. However, they can't clear that highlight by clicking on the canvas - they need to use the `Reset Selection` button.

This change allows users to clear the neighborhood highlight by clicking on the canvas as well.

(I also set a global `highlightActive` variable, because this seems necessary and at some points in testing I got an error without it. I didn't keep good track of what was causing that and can't reproduce it cleanly, but it seemed safer to keep it.)

Fixes #257 