### PR TITLE
Make notebook argument in Network.show default to False

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -533,8 +533,7 @@ class Network(object):
         if open_browser: # open the saved file in a new browser window.
             webbrowser.open(getcwd_name)
 
-
-    def show(self, name, local=True,notebook=True):
+    def show(self, name, local=True, notebook=False):
         """
         Writes a static HTML file and saves it locally before opening.
 
@@ -542,10 +541,9 @@ class Network(object):
         :type name: str
         """
         print(name)
-        if notebook:
-            self.write_html(name, open_browser=False,notebook=True)
-        else:
-            self.write_html(name, open_browser=True)
+
+        open_browser = not notebook
+        self.write_html(name, open_browser=open_browser, notebook=notebook)
         if notebook:
             return IFrame(name, width=self.width, height=self.height)
 


### PR DESCRIPTION
Currently, the `pytest` tests fail, due to `Network.show` being called on `Network` instances that were initialised with `notebook=False`, meaning that `Network.prep_notebook` wasn't called and `self.template` remains as `None`. As `Network.show`'s `notebook` argument defaults to `True`, it by default attempts to call `self.template.render' and errors because `None` doesn't have this method.

This PR changes `show` to default to `notebook=False`, which follows the pattern used in other methods. The pytest tests now pass.

If `notebook=True` really is the desired default for `show`, an alternative is to explicitly set `notebook=False` in the tests.

