### PR TITLE
Fix handling of set_options() function

### DIFF
--- a/pyvis/network.py
+++ b/pyvis/network.py
@@ -779,7 +779,10 @@ class Network(object):
         :type damping: float
         :type overlap: float
         """
-        self.options.physics.use_barnes_hut(locals())
+        if isinstance(self.options, dict):
+            self.options['physics']['solver'] = 'barnes_hut'
+        else:
+            self.options.physics.use_barnes_hut(locals())
 
     def repulsion(
             self,
@@ -808,7 +811,10 @@ class Network(object):
         :type spring_strength: float
         :type damping: float
         """
-        self.options.physics.use_repulsion(locals())
+        if isinstance(self.options, dict):
+            self.options['physics']['solver'] = 'repulsion'
+        else:
+            self.options.physics.use_repulsion(locals())
 
     def hrepulsion(
             self,
@@ -837,7 +843,10 @@ class Network(object):
         :type spring_strength: float
         :type damping: float
         """
-        self.options.physics.use_hrepulsion(locals())
+        if isinstance(self.options, dict):
+            self.options['physics']['solver'] = 'hierarchicalRepulsion'
+        else:
+            self.options.physics.use_hrepulsion(locals())
 
     def force_atlas_2based(
             self,
@@ -877,7 +886,10 @@ class Network(object):
         :type damping: float
         :type overlap: float
         """
-        self.options.physics.use_force_atlas_2based(locals())
+        if isinstance(self.options, dict):
+            self.options['physics']['solver'] = 'forceAtlas2Based'
+        else:
+            self.options.physics.use_force_atlas_2based(locals())
 
     def to_json(self, max_depth=1, **args):
         return jsonpickle.encode(self, max_depth=max_depth, **args)
@@ -897,8 +909,12 @@ class Network(object):
 
         :type smooth_type: string
         """
-        self.options.edges.smooth.enabled = True
-        self.options.edges.smooth.type = smooth_type
+        if isinstance(self.options, dict):
+            self.options['edges']['smooth']['enabled'] = True
+            self.options['edges']['smooth']['type'] = smooth_type
+        else:
+            self.options.edges.smooth.enabled = True
+            self.options.edges.smooth.type = smooth_type
 
     def toggle_hide_edges_on_drag(self, status):
         """
@@ -909,7 +925,10 @@ class Network(object):
         
         :type status: bool
         """
-        self.options.interaction.hideEdgesOnDrag = status
+        if isinstance(self.options, dict):
+            self.options['interaction']['hideEdgesOnDrag'] = status
+        else:
+            self.options.interaction.hideEdgesOnDrag = status
 
     def toggle_hide_nodes_on_drag(self, status):
         """
@@ -921,7 +940,10 @@ class Network(object):
 
         :type status: bool
         """
-        self.options.interaction.hideNodesOnDrag = status
+        if isinstance(self.options, dict):
+            self.options['interaction']['hideNodesOnDrag'] = status
+        else:
+            self.options.interaction.hideNodesOnDrag = status
 
     def inherit_edge_colors(self, status):
         """
@@ -930,7 +952,10 @@ class Network(object):
         :param status: True if edges should adopt color coming from.
         :type status: bool
         """
-        self.options.edges.inherit_colors(status)
+        if isinstance(self.options, dict):
+            self.options['edges']['color']['inherit'] = status
+        else:
+            self.options.edges.inherit_colors(status)
 
     def show_buttons(self, filter_=None):
         """
@@ -956,7 +981,15 @@ class Network(object):
         :type filter_: bool or list:
         """
         self.conf = True
-        self.options.configure = Configure(enabled=True, filter_=filter_)
+        if isinstance(self.options, dict):
+            self.options['configure']['enabled'] = True
+            if filter_ == None:
+                if 'filter' in self.options['configure']:
+                    self.options['configure'].pop('filter')
+            else:
+                self.options['configure']['filter'] = filter_
+        else:
+            self.options.configure = Configure(enabled=True, filter_=filter_)
         self.widget = True
 
     def toggle_physics(self, status):
@@ -970,7 +1003,10 @@ class Network(object):
 
         :type status: bool
         """
-        self.options.physics.enabled = status
+        if isinstance(self.options, dict):
+            self.options['physics']['enabled'] = True
+        else:
+            self.options.physics.enabled = status
 
     def toggle_drag_nodes(self, status):
         """
@@ -981,7 +1017,10 @@ class Network(object):
 
         :type status: bool
         """
-        self.options.interaction.dragNodes = status
+        if isinstance(self.options, dict):
+            self.options['interaction']['dragNodes'] = status
+        else:
+            self.options.interaction.dragNodes = status
 
     def toggle_stabilization(self, status):
         """
@@ -991,7 +1030,10 @@ class Network(object):
 
         :type status: bool
         """
-        self.options.physics.toggle_stabilization(status)
+        if isinstance(self.options, dict):
+            self.options['physics']['stabilization']['enabled'] = status
+        else:
+            self.options.physics.toggle_stabilization(status)
 
     def set_options(self, options):
         """
@@ -1003,4 +1045,32 @@ class Network(object):
         
         :type options: str
         """
-        self.options = self.options.set(options)
+        if isinstance(self.options, dict):
+            def del_nulls(prop_dict):
+                for key in list(prop_dict.keys()):
+                    if (prop_dict[key] == None):
+                            prop_dict.pop(key)
+                    elif isinstance(prop_dict[key], dict):
+                            del_nulls(prop_dict[key])
+                return prop_dict
+
+            def deep_merge(dict1, dict2):
+                merged_dict=dict1
+                
+                for key in dict2:
+                    if (key in dict1) and isinstance(dict1[key], dict) and isinstance(dict2[key], dict):
+                        merged_dict[key] = deep_merge(dict1[key], dict2[key])
+                    else:
+                        merged_dict[key] = dict2[key]
+                return merged_dict
+            
+            new_options = options
+            new_options = new_options.replace("\n", "").replace(" ", "")
+            first_bracket = new_options.find("{")
+            new_options = new_options[first_bracket:]
+            new_options = json.loads(new_options)
+            new_options = del_nulls(new_options)
+            
+            self.options = deep_merge(self.options, new_options)
+        else:
+            self.options = self.options.set(options)

--- a/pyvis/options.py
+++ b/pyvis/options.py
@@ -218,11 +218,35 @@ class Options(object):
         :type new_options: str
         """
         
-        options = new_options.replace("\n", "").replace(" ", "")
-        first_bracket = options.find("{")
-        options = options[first_bracket:]
-        options = json.loads(options)
-        return options
+        def del_nulls(prop_dict):
+            for key in list(prop_dict.keys()):
+                if (prop_dict[key] == None):
+                        prop_dict.pop(key)
+                elif isinstance(prop_dict[key], dict):
+                        del_nulls(prop_dict[key])
+            return prop_dict
+
+        def deep_merge(dict1, dict2):
+            merged_dict=dict1
+            
+            for key in dict2:
+                if (key in dict1) and isinstance(dict1[key], dict) and isinstance(dict2[key], dict):
+                    merged_dict[key] = deep_merge(dict1[key], dict2[key])
+                else:
+                    merged_dict[key] = dict2[key]
+            return merged_dict
+
+        new_options = new_options.replace("\n", "").replace(" ", "")
+        first_bracket = new_options.find("{")
+        new_options = new_options[first_bracket:]
+        new_options = json.loads(new_options)
+        new_options = del_nulls(new_options)
+        
+        current_options = self.to_json()
+        current_options = json.loads(current_options)
+        
+        options_to_set = deep_merge(current_options, new_options)
+        return options_to_set
         
 
     def to_json(self):


### PR DESCRIPTION
Documentation says that `Network.set_options()` should get JSON options, generated by browser, and set it to the Network, but didn't work at all. Now it's fixed inside of options.py file and work perfectly, but with one small peculiarity. It works only after calling all other functions that related to Options class and not after it. Details of my solution you can find in commentary on this topic: https://github.com/WestHealth/pyvis/issues/81#issuecomment-2837830953

The root reason for the bug is that `Network.set_options()` is setting `options` variable to `dict`, but not `Options` class! That's why all functions from `Options` class became unavalieble after calling `Network.set_options()`.

Also there were some smaller issues like:
1.  "Generate options" button generate some options with null-value. When these settings are passed to the function, they are reset and also lead to a breakdown in the visualization of some components. I fixed it with `del_nulls()` subfunction.
2.  "Generate options" button generate not all options that necessary for the execution of the program. Also, before fix `Network.set_options()` rewrote the values of options that were seted before using functions (`Network.set_edge_smooth()`,  `Network.show_buttons()` etc.) That's why `deep_merge(dict1, dict2)` function needed. This merge is "deep", becouse of recursive representation of options in JSON form:

"edges": {
    "color": {
      "inherit": true
    }
}

Therefore, I see two ways to solve this bug complitly, so that users could use set_options() few times and another functions from `Options` class in any order.

First way — is to construnt an `Options` class from JSON instead of reasigning it as dictionary. It's truly problematic becouse of JSON file with options consists not only of `Options` class' members, but of "nodes" and "edges" too, which, as I can see, not represented in python part of pyvis library. Those go to the input of other imported libraries and set defoult color to Nodes and so on(?) I mean — when Node's color is not clarified, it became the color from those options.

And the second way looks easier for me — to check if options is the dict in every function wich operate with it and choose suitable command. It does not require rewriting Options as a class, and similar exception check already exists in pyvis code. But only for one function inside network.py:

![image](https://github.com/user-attachments/assets/6a6ca34b-3229-4376-91eb-48884737328b)

I'll try to implement the second solution in the next commit.