### PR TITLE
Update _version.py to say 0.3.3

### DIFF
--- a/pyvis/_version.py
+++ b/pyvis/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.2.0' # bump version
+__version__ = '0.3.3' # bump version


### PR DESCRIPTION
This package breaks pip check, as it advertises itself as version 0.3.2 on many repositories, but implies its own version is 0.2.0 internally.